### PR TITLE
[Please ignore the last PR]dump index cost result to file 'index-cost' when generating data

### DIFF
--- a/scripts/oap_perf_test.sh
+++ b/scripts/oap_perf_test.sh
@@ -67,7 +67,9 @@ function genData {
     --deploy-mode client \
     --class org.apache.spark.sql.OapPerfSuite \
     ${workDir}/oap-perf-suite/target/scala-2.11/oap-perf-suite-assembly-1.0.jar \
-    -d
+    -d \
+    1>>./index-cost \
+    2>&3
 }
 
 # create task directory and run periodic task

--- a/src/main/scala/org/apache/spark/sql/TestUtil.scala
+++ b/src/main/scala/org/apache/spark/sql/TestUtil.scala
@@ -104,6 +104,22 @@ object TestUtil {
       println(Tabulator.format(Seq(header) ++ content))
     }
   }
+
+  def formatIndexResults(resultSet: Seq[(String, Seq[(String, Array[String])])]): Unit = {
+    assert(resultSet.nonEmpty)
+
+    resultSet.foreach{ result =>
+      val header =
+        Seq(("%" + Tabulator.MAX_WIDTH + "s").format(Tabulator.truncate(result._1))) ++
+          Seq("Index construction time/ms") ++
+          Seq("Index size")
+      val content = result._2.map(x =>
+        Seq(Tabulator.truncate(x._1)) ++
+        x._2.toSeq
+      )
+      println(Tabulator.format(Seq(header) ++ content))
+    }
+  }
 }
 
 // TODO: use DataSet.show()??


### PR DESCRIPTION
1, Modified the return value of methods "buildBtreeIndex" and "buildBitmapIndex" in class OapBenchmarkDataBuilder from Unit to (String, Array[String]), which is the index cost.
2, Add the private _resultMap variable to class OapBenchmarkDataBuilder, similar to that in the test suite.
3, At the same time, modify the script oap_perf_test.sh to output the result to file 'index-cost'.
4, Still has the analyze.py part to do.